### PR TITLE
Doc updates + change signal.dataType to ..signal

### DIFF
--- a/examples/random-data-example.json
+++ b/examples/random-data-example.json
@@ -7,7 +7,7 @@
         "apiRef": "715050d8.0a98a",
         "signalId": "payload.id",
         "signalName": "payload.name",
-        "signalDataType": "payload.dataType",
+        "signalType": "payload.type",
         "signalDescription": "payload.description",
         "signalLabels": "payload.labels",
         "signalAnnotations": "payload.annotations",

--- a/nodes/clarify_insert.html
+++ b/nodes/clarify_insert.html
@@ -22,8 +22,8 @@
           value: 'payload.name',
           required: true,
         },
-        signalDataType: {
-          value: 'payload.dataType',
+        signalType: {
+          value: 'payload.type',
           required: true,
         },
         signalDescription: {
@@ -125,8 +125,8 @@
       <input type="text" class="msg-field" id="node-input-signalName" style="width:70%" />
     </div>
     <div class="form-row">
-      <label for="node-input-signalDataType"><span data-i18n="clarify_insert.label.dataType"></label>
-      <input type="text" class="msg-field" id="node-input-signalDataType" style="width:70%" />
+      <label for="node-input-signalType"><span data-i18n="clarify_insert.label.type"></label>
+      <input type="text" class="msg-field" id="node-input-signalType" style="width:70%" />
     </div>
     <div class="form-row">
       <label for="node-input-signalDescription"><span data-i18n="clarify_insert.label.description"></label>

--- a/nodes/clarify_insert.js
+++ b/nodes/clarify_insert.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var Mutex = require('async-mutex').Mutex;
 
-const signalIdPattern = /^[a-z0-9_-]{1,40}$/;
+const clarifyInputIdRegEx = /^[a-z0-9_-]{1,40}$/;
 
 module.exports = function (RED) {
   var util = require('./clarify_util');
@@ -174,7 +174,7 @@ module.exports = function (RED) {
         done(errMsg);
         return;
       }
-      if (!signalIdPattern.test(id)) {
+      if (!clarifyInputIdRegEx.test(id)) {
         let errMsg = 'invalid signal id';
         node.status({fill: 'red', shape: 'ring', text: errMsg});
         done(`${errMsg}: ${id}`);

--- a/nodes/clarify_util.js
+++ b/nodes/clarify_util.js
@@ -80,7 +80,7 @@ module.exports = {
   },
   prepareSignal: function (RED, msg, config) {
     let name = RED.util.getMessageProperty(msg, config.signalName);
-    let dataType = RED.util.getMessageProperty(msg, config.signalDataType);
+    let type = RED.util.getMessageProperty(msg, config.signalType);
     let description = RED.util.getMessageProperty(msg, config.signalDescription);
     let engUnit = RED.util.getMessageProperty(msg, config.signalEngUnit);
     let labels = RED.util.getMessageProperty(msg, config.signalLabels);
@@ -92,7 +92,7 @@ module.exports = {
 
     let validationErrors = [];
     validateString(validationErrors, 'name', name);
-    validateString(validationErrors, 'dataType', dataType);
+    validateString(validationErrors, 'type', type);
     validateString(validationErrors, 'description', description);
     validateMapStringWithStrings(validationErrors, 'labels', labels);
     validateMapStringWithStrings(validationErrors, 'annotations', annotations);
@@ -108,7 +108,7 @@ module.exports = {
 
     let signal = {};
     assignIfDefined(signal, 'name', name);
-    assignIfDefined(signal, 'type', dataType);
+    assignIfDefined(signal, 'type', type);
     assignIfDefined(signal, 'description', description);
     assignIfDefined(signal, 'labels', labels);
     assignIfDefined(signal, 'annotations', annotations);
@@ -134,10 +134,10 @@ function validateString(validationErrors, varName, variable) {
   // Field spesific validations
   let allowed = [];
   switch (varName) {
-    case 'dataType':
+    case 'type':
       allowed = ['enum', 'numeric'];
       if (!allowed.includes(variable)) {
-        validationErrors.push('unsupported dataType: ' + variable);
+        validationErrors.push('unsupported type: ' + variable);
       }
       break;
     case 'sourceType':

--- a/nodes/locales/en-US/clarify_insert.html
+++ b/nodes/locales/en-US/clarify_insert.html
@@ -21,8 +21,8 @@
     <dd>The name used for the signal. Defaults to the signal ID.</dd>
     <dd>Expects: string</dd>
 
-    <dt class="optional">Data type <span class="property-type">msg.payload.dataType</span></dt>
-    <dd>The data type for the signal. Must be set as msg.payload.dataType and be either numeric or enum. Defaults to numeric.</dd>
+    <dt class="optional">Type <span class="property-type">msg.payload.type</span></dt>
+    <dd>The type for the signal. Must be set as msg.payload.type and be either numeric or enum. Defaults to numeric.</dd>
     <dd>Expects: numeric | enum</dd>
 
     <dt class="optional">Description <span class="property-type">msg.payload.description</span></dt>
@@ -91,7 +91,7 @@
   {
     "id": "id100",
     "name": "Ice Cream Temperature",
-    "dataType": "numeric",
+    "type": "numeric",
     "description": "Temperature measurement of the ice cream",
     "labels": {
       "flavours": [

--- a/nodes/locales/en-US/clarify_insert.html
+++ b/nodes/locales/en-US/clarify_insert.html
@@ -14,7 +14,7 @@
   <h3>Inputs</h3>
   <dl class="message-properties">
     <dt>ID <span class="property-type">msg.payload.id</span></dt>
-    <dd>A unique id per signal that has to match the regex for Clarify ID's <code>/^[a-z0-9_-]{1,40}$/</code>. If the id is changed will a new signal be created.</dd>
+    <dd>A unique id per signal that has to match the regex for the Clarify Input ID, <code>/^[a-z0-9_-]{1,40}$/</code>. If the id is changed will a new signal be created.</dd>
     <dd>Expects: string</dd>
 
     <dt>Name <span class="property-type">msg.payload.name</span></dt>
@@ -29,7 +29,7 @@
     <dd>Description of the signal. Defaults to empty.</dd>
     <dd>Expects: string</dd>
 
-    <dt class="optional">annotations <span class="property-type">msg.payload.labels</span></dt>
+    <dt class="optional">Labels <span class="property-type">msg.payload.labels</span></dt>
     <dd>Labels.</dd>
     <dd>Expects: Map[string]string[].</dd>
     <dd>Example: <code>{"equipment":["fan","engine"]}</code></dd>

--- a/nodes/locales/en-US/clarify_insert.json
+++ b/nodes/locales/en-US/clarify_insert.json
@@ -6,7 +6,7 @@
       "credentials": "Credentials",
       "dataSeries": "Data series",
       "dataTimes": "Data times",
-      "dataType": "Data type",
+      "type": "Type",
       "description": "Description",
       "engUnit": "Eng. unit",
       "enumValues": "Enum values",


### PR DESCRIPTION
commit 6eb3ca6fb190eb8383697c207145f54cffd50f18
Author: Kjetil Hope Tufteland <kjetil@searis.no>
Date:   Wed Apr 28 11:33:37 2021 +0200

    Change signal from dataType to type
    
    Legacy version of Clarify uses dataType, but new version has changed to
    type.

commit 7bacab79df322614b57e880941b5739694d8a3b9
Author: Kjetil Hope Tufteland <kjetil@searis.no>
Date:   Tue Apr 27 11:28:34 2021 +0200

    clarify_insert: Improve variable name
    
    States more explicitly that variable content refers to Clarify Input ID
    regex.

commit 2753f5a573ef0a9cbe035fb9845c8905f059d6a5
Author: Kjetil Hope Tufteland <kjetil@searis.no>
Date:   Tue Apr 27 11:17:08 2021 +0200

    clarify_insert: Minor typo in doc + specify that id is Clarify Input ID
