### PR TITLE
clarify_insert: Shift data buffer flush time based on ensure flush time + misc changes

### DIFF
--- a/nodes/clarify_insert.html
+++ b/nodes/clarify_insert.html
@@ -10,7 +10,7 @@
           value: '5',
           required: true,
           validate: function (v) {
-            return RED.validators.number(v) && v >= 1;
+            return RED.validators.number(v) && v > 1;
           },
         },
       },
@@ -42,7 +42,7 @@
   </div>
   <div class="form-row">
     <label for="node-input-bufferTime"><i class="fa fa-clock-o"></i> <span data-i18n="clarify_insert.label.bufferTime"></span></label>
-    <input type="number" id="node-input-bufferTime" min="1" style="text-align:end; width:100px !important">
+    <input type="number" id="node-input-bufferTime" min="2" style="text-align:end; width:100px !important">
     <label for="label"><span data-i18n="clarify_insert.label.secs"></label>
   </div>
 </script>

--- a/nodes/clarify_util.js
+++ b/nodes/clarify_util.js
@@ -122,7 +122,7 @@ module.exports = {
   },
 
   hashSignal(signal) {
-    return CryptoJS.SHA1(JSON.stringify(signal)).toString();
+    return CryptoJS.MD5(JSON.stringify(signal)).toString();
   },
 };
 


### PR DESCRIPTION
commit f5373ac31d93d021f669005ef5e44d7de0073dba
Author: Kjetil Hope Tufteland <kjetil@searis.no>
Date:   Tue Sep 7 10:53:47 2021 +0200

    clarify_insert: Increase minimum bufferTime to 2
    
    Was allowed in frontend (html), but not allowed in backend.

commit 0bf6863be432075b5876ec3d19ec0b23ffc9c8fd
Author: Kjetil Hope Tufteland <kjetil@searis.no>
Date:   Tue Sep 7 10:49:47 2021 +0200

    clarify_insert: Shift data buffer flush time based on ensure flush time
    
    Long story short. We want that data operations to be written 1 second
    after SaveSignals (ensure) operations are completed.

commit 60c0d0a4c142020f50fa7ac8eec08bee267be3ef
Author: Kjetil Hope Tufteland <kjetil@searis.no>
Date:   Tue Sep 7 10:41:03 2021 +0200

    clarify_util: Change signalHash method from sha1 to md5
    
    More fit for purpose since we're calculating a checksum.
