### PR TITLE
clarify_db: Wrong method, should be write, not value

### DIFF
--- a/nodes/clarify_db.js
+++ b/nodes/clarify_db.js
@@ -69,7 +69,7 @@ module.exports = class ClarifyDb {
   }
 
   patchSignal(integrationId, inputId, hash) {
-    return this.getDb(integrationId).get('signals').find({inputId: inputId}).assign({hash: hash}).value();
+    return this.getDb(integrationId).get('signals').find({inputId: inputId}).assign({hash: hash}).write();
   }
 
   createSignal(integrationId, inputId, hash) {


### PR DESCRIPTION
commit ea9b2237cee30b87bd85ae23b32e4225b8c7d3fb
Author: Kjetil Hope Tufteland <kjetil@searis.no>
Date:   Tue Sep 7 14:11:21 2021 +0200

    clarify_db: Wrong method, should be write, not value
