### PR TITLE
clarify_db: Don't use private methods

### DIFF
--- a/nodes/clarify_db.js
+++ b/nodes/clarify_db.js
@@ -13,12 +13,12 @@ module.exports = class ClarifyDb {
 
   constructor(userDir) {
     this.folderName = userDir + '/clarify-db';
-    this.#createDbFolder(this.folderName);
+    this.createDbFolder(this.folderName);
 
-    this.#deletePreviousVersions(userDir);
+    this.deletePreviousVersions(userDir);
   }
 
-  #createDbFolder(folderName) {
+  createDbFolder(folderName) {
     try {
       if (!fs.existsSync(folderName)) {
         fs.mkdirSync(folderName);
@@ -28,7 +28,7 @@ module.exports = class ClarifyDb {
     }
   }
 
-  #deletePreviousVersions(userDir) {
+  deletePreviousVersions(userDir) {
     // previousVersions contains a list of all previous known versions of this database.
     let previousVersions = [userDir + '/clarify_db.json'];
     previousVersions.forEach(path => {


### PR DESCRIPTION
commit b8e386abe2ea261c7cdfe8a14a19d043dfc7149b
Author: Kjetil Hope Tufteland <kjetil@searis.no>
Date:   Tue Sep 7 23:25:17 2021 +0200

    clarify_db: Don't use private methods
    
    Not supported by lower versions of Node.
